### PR TITLE
Fixing unit tests on Windows

### DIFF
--- a/R/pwr_ttestis.R
+++ b/R/pwr_ttestis.R
@@ -227,10 +227,10 @@ ttestISClass <- R6::R6Class(
       html[["text"]] <- str
 
       esText <- c(
-        gettextf("0 < \u03B4 \u2264 %s", format(round(probs_es[1], 3), nsmall = 3)),
-        gettextf("%s < \u03B4 \u2264 %s", format(round(probs_es[1], 3), nsmall = 3), format(round(probs_es[2], 3), nsmall = 3)),
-        gettextf("%s < \u03B4 \u2264 %s",format(round(probs_es[2], 3), nsmall = 3), format(round(probs_es[3], 3), nsmall = 3)),
-        gettextf("\u03B4 \u2265 %s", format(round(probs_es[3], 3), nsmall = 3))
+        gettextf("0 < %s %s  %s", "\u03B4", "\u2264", format(round(probs_es[1], 3), nsmall = 3)),
+        gettextf("%s < %s %s %s", format(round(probs_es[1], 3), nsmall = 3), "\u03B4", "\u2264", format(round(probs_es[2], 3), nsmall = 3)),
+        gettextf("%s < %s %s %s",format(round(probs_es[2], 3), nsmall = 3), "\u03B4", "\u2264", format(round(probs_es[3], 3), nsmall = 3)),
+        gettextf("%s %s %s", "\u03B4", "\u2265", format(round(probs_es[3], 3), nsmall = 3))
       )
 
       cols <- list("es" = esText)

--- a/R/pwr_ttestps.R
+++ b/R/pwr_ttestps.R
@@ -361,10 +361,10 @@ ttestPSClass <- R6::R6Class(
             probs_es <- private$probs_es
 
             esText <- c(
-                gettextf("0 < \u03B4 \u2264 %s", format(round(probs_es[1], 3), nsmall = 3)),
-                gettextf("%s < \u03B4 \u2264 %s", format(round(probs_es[1], 3), nsmall = 3), format(round(probs_es[2], 3), nsmall = 3)),
-                gettextf("%s < \u03B4 \u2264 %s", format(round(probs_es[2], 3), nsmall = 3), format(round(probs_es[3], 3), nsmall = 3)),
-                gettextf("\u03B4 \u2265 %s", format(round(probs_es[3], 3), nsmall = 3))
+              gettextf("0 < %s %s  %s", "\u03B4", "\u2264", format(round(probs_es[1], 3), nsmall = 3)),
+              gettextf("%s < %s %s %s", format(round(probs_es[1], 3), nsmall = 3), "\u03B4", "\u2264", format(round(probs_es[2], 3), nsmall = 3)),
+              gettextf("%s < %s %s %s",format(round(probs_es[2], 3), nsmall = 3), "\u03B4", "\u2264", format(round(probs_es[3], 3), nsmall = 3)),
+              gettextf("%s %s %s", "\u03B4", "\u2265", format(round(probs_es[3], 3), nsmall = 3))
             )
 
             cols <- list("es" = esText)

--- a/R/tTestBaseClass.R
+++ b/R/tTestBaseClass.R
@@ -194,7 +194,7 @@ tTestBaseClass <- R6::R6Class(
         ggplot2::scale_x_log10(sec.axis = secondary_axis) +
         ggplot2::labs(
           x = gettext("Sample size (group 1)"),
-          y = gettext("Hypothetical effect size (δ)"),
+          y = gettextf("Hypothetical effect size (%s)", "\u03B4"),
           fill = gettext("Power")
         ) +
         ggplot2::guides(fill = ggplot2::guide_colorsteps(barheight = ggplot2::unit(7, "cm"))) +
@@ -255,7 +255,7 @@ tTestBaseClass <- R6::R6Class(
       p <- p +
         ggplot2::geom_line(size = 1.5) +
         ggplot2::labs(
-          x = gettext("Hypothetical effect size (δ)"),
+          x = gettextf("Hypothetical effect size (%s)", "\u03B4"),
           y = gettext("Power"),
           subtitle = plot_subtitle
         ) +


### PR DESCRIPTION
-On Windows, the unicode symbols (e.g., delta) do only render correctly when pasted together